### PR TITLE
Add coding utf-8 to importmagicserver

### DIFF
--- a/importmagicserver.py
+++ b/importmagicserver.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 importmagic.el server
 ---------------------


### PR DESCRIPTION
I got the same issue as @gchpaco and adding the encoding declaration at the top of `importmagicserver.py` does help. 