### PR TITLE
Allow style configuration to be passed through to importmagic.Imports

### DIFF
--- a/importmagic.el
+++ b/importmagic.el
@@ -64,6 +64,12 @@
   "The importmagic index server.")
 (make-variable-buffer-local 'importmagic-server)
 
+(defvar importmagic-style-configuration
+  '((multiline max_columns)
+    (parentheses 79))
+  "Arguments to be passed to importmagic.Imports.set_style.")
+(make-variable-buffer-local 'importmagic-style-configuration)
+
 (defun importmagic--message (msg &rest args)
   "Show the message MSG with ARGS only if importmagic is set to not be quiet."
   (when (not importmagic-be-quiet)
@@ -133,7 +139,8 @@
   "Query importmagic server for STATEMENT imports in the current buffer."
   (let* ((specs (epc:call-sync importmagic-server
                                'get_import_statement
-                               `(,(importmagic--buffer-as-string) ,statement)))
+                               `(,(importmagic--buffer-as-string)
+                                 ,statement ,importmagic-style-configuration)))
          (start (car specs))
          (end (cadr specs))
          (theblock (caddr specs)))


### PR DESCRIPTION
This should allow the user to define importmagic-style-configuration
as a list of lists (for keys and values) to be passed directly through
to importmagic.Imports.set_style to control the style in which imports
are rewritten.

Fixes: #6

I took a stab at this, the elisp defaults are based on what the defaults for the actual `importmagic` are. I resorted to passing a list of lists rather than trying to figure out how to force and `alist` into a `dict` (epc is very foreign to me). Also, I found I was able to get rid of the star-arg parsing for `get_import_statement`, it *seems* unnecessary if passing multiple arguments.