### PR TITLE
Now uses python-shell-interpreter instead of hardcoded "python"

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ affect importmagic, but it also affects
 Jedi. See
 [this issue](https://github.com/davidhalter/jedi/issues/531).
 
+If you are using ipython as default python-shell-interpreter use
+``` shell
+(setq-default python-shell-interpreter-args '("--no-banner"))
+```
+Because epc requires the port number should be in the first three lines
+
 ## Contributing
 Any kind of contribution is absolutely welcome.
 

--- a/importmagic.el
+++ b/importmagic.el
@@ -103,14 +103,16 @@ seen on https://github.com/alecthomas/importmagic."
             keymap)
   (when (not (derived-mode-p 'python-mode))
     (error "Importmagic only works with Python buffers"))
-  (let ((importmagic-path (f-slash (f-dirname (locate-library "importmagic")))))
+  (let ((importmagic-path (f-slash (f-dirname (locate-library "importmagic"))))
+        (py-interpreter (if (boundp 'python-shell-interpreter) python-shell-interpreter "python"))
+        (py-args (if (boundp 'python-shell-interpreter-args) python-shell-interpreter-args "")))
     (if importmagic-mode
         (progn
           (condition-case nil
               (progn
                 (setq importmagic-server
-                      (epc:start-epc "python"
-                                     `(,(f-join importmagic-path "importmagicserver.py"))))
+                      (epc:start-epc py-interpreter
+                                     `(,py-args ,(f-join importmagic-path "importmagicserver.py"))))
                 (add-hook 'kill-buffer-hook 'importmagic--teardown-epc)
                 (add-hook 'before-revert-hook 'importmagic--teardown-epc)
                 (importmagic--auto-update-index))

--- a/importmagic.el
+++ b/importmagic.el
@@ -105,14 +105,15 @@ seen on https://github.com/alecthomas/importmagic."
     (error "Importmagic only works with Python buffers"))
   (let ((importmagic-path (f-slash (f-dirname (locate-library "importmagic"))))
         (py-interpreter (if (boundp 'python-shell-interpreter) python-shell-interpreter "python"))
-        (py-args (if (boundp 'python-shell-interpreter-args) python-shell-interpreter-args "")))
+        (py-args (if (boundp 'python-shell-interpreter-args) python-shell-interpreter-args '())))
     (if importmagic-mode
         (progn
           (condition-case nil
               (progn
                 (setq importmagic-server
                       (epc:start-epc py-interpreter
-                                     `(,py-args ,(f-join importmagic-path "importmagicserver.py"))))
+                                     append(py-args
+                                            `(,(f-join importmagic-path "importmagicserver.py")))))
                 (add-hook 'kill-buffer-hook 'importmagic--teardown-epc)
                 (add-hook 'before-revert-hook 'importmagic--teardown-epc)
                 (importmagic--auto-update-index))


### PR DESCRIPTION
Fixes #10 

I had a problem using this library with python3, thus I've changed so that it uses python-shell-interpreter instead of hardcoded "python"  py-args local variable added to make this work with ipython as well.

