### PR TITLE
Uses python-shell-interpreter instead of hardcoded "python"

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ and set it to nil in `importmagic-mode-map` like so:
 (define-key importmagic-mode-map (kbd "C-c C-f") nil)
 ```
 
+If you are using ipython as default python-shell-interpreter use
+``` emacs-lisp
+(setq-default python-shell-interpreter-args '("--no-banner"))
+```
+Because epc requires the port number should be in the first three lines
 
 ### Annoyances
 

--- a/importmagic.el
+++ b/importmagic.el
@@ -103,14 +103,16 @@ seen on https://github.com/alecthomas/importmagic."
             keymap)
   (when (not (derived-mode-p 'python-mode))
     (error "Importmagic only works with Python buffers"))
-  (let ((importmagic-path (f-slash (f-dirname (locate-library "importmagic")))))
+  (let ((importmagic-path (f-slash (f-dirname (locate-library "importmagic"))))
+        (py-interpreter (if (boundp 'python-shell-interpreter) python-shell-interpreter "python"))
+        (py-args (if (boundp 'python-shell-interpreter-args) python-shell-interpreter-args "")))
     (if importmagic-mode
         (progn
           (condition-case nil
               (progn
                 (setq importmagic-server
-                      (epc:start-epc "python"
-                                     `(,(f-join importmagic-path "importmagicserver.py"))))
+                      (epc:start-epc py-interpreter
+                                     `(,py-args ,(f-join importmagic-path "importmagicserver.py"))))
                 (add-hook 'kill-buffer-hook 'importmagic--teardown-epc)
                 (add-hook 'before-revert-hook 'importmagic--teardown-epc)
                 (importmagic--auto-update-index))


### PR DESCRIPTION
Fixes #10

Although the fix is general and should work for ipython as well, I didn't test ipython as I only use python3 currently. (It was working for ipython at the time I submitted this PR before)