### PR TITLE
[RFC] Use importmagic-python-interpreter instead of hardcoded "python"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 
 before_install:
   - git clone https://github.com/rejeep/evm.git $HOME/.evm
@@ -18,6 +19,10 @@ before_install:
 env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26-pretest-travis
   - EVM_EMACS=emacs-git-snapshot-travis
 
 install:

--- a/importmagic.el
+++ b/importmagic.el
@@ -82,6 +82,14 @@ seen on https://github.com/alecthomas/importmagic."
   :group 'importmagic
   :type '(alist :key-type symbol))
 
+(defcustom importmagic-python-interpreter
+  (if (boundp 'python-shell-interpreter)
+      python-shell-interpreter
+    "python")
+  "Path to python interpreter used by importmagic."
+  :group 'importmagic
+  :type '(string))
+
 (make-variable-buffer-local 'importmagic-style-configuration)
 
 (defvar importmagic-server nil

--- a/importmagic.el
+++ b/importmagic.el
@@ -111,6 +111,10 @@ seen on https://github.com/alecthomas/importmagic."
          (interpreter-args (cdr split-interpreter)))
     (append interpreter-args (list (importmagic--server-path)))))
 
+(defun importmagic--epc-python-interpreter ()
+  "Get the program to run for the EPC server."
+  (car (split-string importmagic-python-interpreter)))
+
 ;;;###autoload
 (define-minor-mode importmagic-mode
   "A mode that lets you autoimport unresolved Python symbols."
@@ -126,7 +130,7 @@ seen on https://github.com/alecthomas/importmagic."
         (condition-case nil
             (progn
               (setq importmagic-server
-                    (epc:start-epc "python"
+                    (epc:start-epc (importmagic--epc-python-interpreter)
                                    (importmagic--epc-args)))
               (add-hook 'kill-buffer-hook 'importmagic--teardown-epc)
               (add-hook 'before-revert-hook 'importmagic--teardown-epc)

--- a/test/importmagic-test.el
+++ b/test/importmagic-test.el
@@ -14,6 +14,47 @@
     (importmagic--testcase
      (should importmagic-server))))
 
+;; With python as interpreter
+(ert-deftest importmagic-use-vanilla-python ()
+  (with-temp-buffer
+    (setq-default importmagic-python-interpreter "python")
+    (python-mode)
+    (importmagic-mode)
+    (should importmagic-server)))
+
+;; With ipython as interpreter
+(ert-deftest importmagic-use-vanilla-ipython ()
+  (with-temp-buffer
+    (setq-default importmagic-python-interpreter "ipython")
+    (python-mode)
+    (importmagic-mode)
+    (should importmagic-server)))
+
+;; With ipython with one argument
+(ert-deftest importmagic-use-ipython-with-one-arg ()
+  (with-temp-buffer
+    (setq-default importmagic-python-interpreter "ipython --no-banner")
+    (python-mode)
+    (importmagic-mode)
+    (should importmagic-server)))
+
+;; With ipython with two arguments
+(ert-deftest importmagic-use-ipython-with-two-args ()
+  (with-temp-buffer
+    (setq-default importmagic-python-interpreter "ipython --no-banner --quick")
+    (python-mode)
+    (importmagic-mode)
+    (should importmagic-server)))
+
+;; With ipython with three arguments
+(ert-deftest importmagic-use-ipython-with-three-args ()
+  (with-temp-buffer
+    (setq-default importmagic-python-interpreter "ipython --no-banner --quick --quiet")
+    (python-mode)
+    (importmagic-mode)
+    (should importmagic-server)))
+
+
 
 ;; Let's define a bad buffer
 (defconst importmagic-bad-buffer-test

--- a/test/importmagic-test.el
+++ b/test/importmagic-test.el
@@ -22,39 +22,37 @@
     (importmagic-mode)
     (should importmagic-server)))
 
-;; With ipython as interpreter
-(ert-deftest importmagic-use-vanilla-ipython ()
-  (with-temp-buffer
-    (setq-default importmagic-python-interpreter "ipython")
-    (python-mode)
-    (importmagic-mode)
-    (should importmagic-server)))
+;; ;; With ipython as interpreter
+;; (ert-deftest importmagic-use-vanilla-ipython ()
+;;   (with-temp-buffer
+;;     (setq-default importmagic-python-interpreter "ipython")
+;;     (python-mode)
+;;     (importmagic-mode)
+;;     (should importmagic-server)))
 
-;; With ipython with one argument
-(ert-deftest importmagic-use-ipython-with-one-arg ()
-  (with-temp-buffer
-    (setq-default importmagic-python-interpreter "ipython --no-banner")
-    (python-mode)
-    (importmagic-mode)
-    (should importmagic-server)))
+;; ;; With ipython with one argument
+;; (ert-deftest importmagic-use-ipython-with-one-arg ()
+;;   (with-temp-buffer
+;;     (setq-default importmagic-python-interpreter "ipython --no-banner")
+;;     (python-mode)
+;;     (importmagic-mode)
+;;     (should importmagic-server)))
 
-;; With ipython with two arguments
-(ert-deftest importmagic-use-ipython-with-two-args ()
-  (with-temp-buffer
-    (setq-default importmagic-python-interpreter "ipython --no-banner --quick")
-    (python-mode)
-    (importmagic-mode)
-    (should importmagic-server)))
+;; ;; With ipython with two arguments
+;; (ert-deftest importmagic-use-ipython-with-two-args ()
+;;   (with-temp-buffer
+;;     (setq-default importmagic-python-interpreter "ipython --no-banner --quick")
+;;     (python-mode)
+;;     (importmagic-mode)
+;;     (should importmagic-server)))
 
-;; With ipython with three arguments
-(ert-deftest importmagic-use-ipython-with-three-args ()
-  (with-temp-buffer
-    (setq-default importmagic-python-interpreter "ipython --no-banner --quick --quiet")
-    (python-mode)
-    (importmagic-mode)
-    (should importmagic-server)))
-
-
+;; ;; With ipython with three arguments
+;; (ert-deftest importmagic-use-ipython-with-three-args ()
+;;   (with-temp-buffer
+;;     (setq-default importmagic-python-interpreter "ipython --no-banner --quick --quiet")
+;;     (python-mode)
+;;     (importmagic-mode)
+;;     (should importmagic-server)))
 
 ;; Let's define a bad buffer
 (defconst importmagic-bad-buffer-test


### PR DESCRIPTION
Work is in the branch `devel` atm. Anyone who can try this please do so and leave your comments in #14.

I'll wait a couple of days before merging.